### PR TITLE
Undo #55. updateAction does not use array in params

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,2 @@
+Fix #75 (undo #55) Params in updateAction is not an array
+

--- a/lib/models/visualRules.js
+++ b/lib/models/visualRules.js
@@ -164,8 +164,8 @@ function vr2rule(cardRule) {
                 case 'updateAttribute':
                     action.type = 'update';
                     action.parameters = {
-                        name: card.actionData.userParams[0].name,
-                        value: card.actionData.userParams[0].value
+                        name: card.actionData.userParams.name,
+                        value: card.actionData.userParams.value
                     };
                     break;
                 default:

--- a/test/data/good_vrs/visual_rule_updateAction.json
+++ b/test/data/good_vrs/visual_rule_updateAction.json
@@ -29,12 +29,12 @@
         {
             "type": "ActionCard",
             "actionData": {
-                "userParams": [
+                "userParams":
                     {
                         "name": "attribute to update",
                         "value": "value for attribute"
                     }
-                ],
+                ,
                 "name": "action card  name",
                 "type": "updateAttribute"
             },


### PR DESCRIPTION
As sent by portal, a plain object instead of an array.

Fermin: solves issue #55 

(Urgent!  Please, ASAP)

@iariasleon 
@fgalan 
@dmoranj 