### PR TITLE
Use a simulated sms endpoint for testing no-signal alarms

### DIFF
--- a/test/component/nsr_test.js
+++ b/test/component/nsr_test.js
@@ -24,6 +24,7 @@
 'use strict';
 
 var
+    util = require('util'),
     async = require('async'),
     should = require('should'),
     utilsT = require('../utils/utilsT'),
@@ -52,6 +53,7 @@ describe('Entity', function() {
             ],
             checkInterval = 1,
             rule = utilsT.loadExample('./test/data/no_signal/generic_nonsignal.json');
+        utilsT.getConfig().sms.URL = util.format('http://localhost:%s', utilsT.fakeHttpServerPort);
         this.timeout(2 * checkInterval * 60e3);
         it('should return silent entities', function(done) {
             var start = Date.now();
@@ -70,7 +72,8 @@ describe('Entity', function() {
                 function(cb) {
                     // wait checker set at AddNSRule to wake up, created by POST of VR
                     setTimeout(cb, 1.25 * checkInterval * 60e3);
-                }, function(cb) {
+                },
+                function(cb) {
                     async.eachSeries(entities, function(entity) {
                         executionsStore.LastTime(DEFAULT_SERVICE, DEFAULT_SUBSERVICE, rule.name, entity._id.id,
                             function(error, time) {

--- a/test/data/no_signal/generic_nonsignal.json
+++ b/test/data/no_signal/generic_nonsignal.json
@@ -60,26 +60,18 @@
         {
             "type": "ActionCard",
             "actionData": {
+                "name": "sms",
+                "type": "SendSmsMibAction",
                 "userParams": [
                     {
-                        "name": "mail.from",
-                        "value": "brox@tid.es"
+                        "name": "sms.to",
+                        "value": "12345678"
                     },
                     {
-                        "name": "mail.to",
-                        "value": "brox@tid.es"
-                    },
-                    {
-                        "name": "mail.subject",
-                        "value": "Sin señal"
-                    },
-                    {
-                        "name": "mail.message",
-                        "value": "${id}  (${type}) lleva ${reportInterval}, desde ${lastTime} sin hablar\nat=${at}"
+                        "name": "sms.message",
+                        "value": "${device.asset.UserProps.threshold.major} message"
                     }
-                ],
-                "name": "email",
-                "type": "SendEmailAction"
+                ]
             },
             "id": "card_12",
             "connectedTo": [ ]


### PR DESCRIPTION
Fixes #91 

A working SMTP server is not necessary anymore
Tests should pass with the default configuration

@fgalan 
@dmoranj 
@jcalderin 
