### PR TITLE
FIX Orion DB Mongo reference missing

### DIFF
--- a/bin/perseo
+++ b/bin/perseo
@@ -63,7 +63,7 @@ function loadConfiguration() {
     }
     if (process.env.PERSEO_MONGO_HOST) {
         config.mongo.url = 'mongodb://' + process.env.PERSEO_MONGO_HOST + ':27017/cep';
-        config.mongo.url = 'mongodb://' + process.env.PERSEO_MONGO_HOST + ':27017/orion';
+        config.orionDb.url = 'mongodb://' + process.env.PERSEO_MONGO_HOST + ':27017/orion';
     }
     if (process.env.PERSEO_CORE_URL) {
         config.perseoCore.rulesURL = process.env.PERSEO_CORE_URL + '/perseo-core/rules';


### PR DESCRIPTION
Configuration of the MongoDB reference overwrite another configuration parameter.