### PR TITLE
Bug/128 old orion model

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,3 @@
 - Fix: serialize actions execution
+- Fix: Use current orion db model for no-sigal rules (#128)
+

--- a/lib/models/entitiesStore.js
+++ b/lib/models/entitiesStore.js
@@ -40,11 +40,8 @@ function findSilentEntities(service, subservice, ruleData, func, callback) {
         criterion = {};
 
     db = orionServiceDb(service);
-    criterion.attrs = {
-        '$elemMatch': {
-            name: ruleData.attribute,
-            modDate: {'$lt': (Date.now() / 1000 - ruleData.reportInterval)}
-        }
+    criterion['attrs.' + ruleData.attribute + '.modDate'] = {
+        '$lt': (Date.now() / 1000 - ruleData.reportInterval)
     };
     criterion['_id.servicePath'] = subservice;
     if (ruleData.id) {

--- a/lib/models/noSignal.js
+++ b/lib/models/noSignal.js
@@ -63,20 +63,19 @@ function alertFunc(nsLineRule, entity) {
         // Search for modDate of the entity's attribute
         // and copy every attribute (if not in event yet)
         // for use in action template
-        if (util.isArray(entity.attrs)) {
-            entity.attrs.forEach(function(attr) {
-                if (attr.name === nsLineRule[ATTRIBUTE]) {
-                    try {
-                        lastTime = (new Date(attr.modDate * 1000)).toISOString();
-                    } catch (ex) {
-                        myutils.logErrorIf(ex);
-                    }
+        Object.keys(entity.attrs).forEach(function(attrName) {
+            if (attrName === nsLineRule[ATTRIBUTE]) {
+                try {
+                    lastTime = (new Date(entity.attrs[attrName].modDate * 1000)).toISOString();
+                } catch (ex) {
+                    myutils.logErrorIf(ex);
                 }
-                if (event[attr.name] === undefined) {
-                    event[attr.name] = attr.value;
-                }
-            });
-        }
+            }
+            if (event[attrName] === undefined) {
+                event[attrName] = entity.attrs[attrName].value;
+            }
+        });
+
         logger.debug('lastTime could be ', lastTime);
         if (lastTime !== undefined && lastTime !== null) {
             event.lastTime = lastTime;

--- a/test/component/nsr_test.js
+++ b/test/component/nsr_test.js
@@ -40,19 +40,29 @@ describe('Entity', function() {
 
     describe('#alertFunc()', function() {
         var entities = [
-                {_id: {id: 'eA', servicePath: DEFAULT_SUBSERVICE, type: 'type e1'}, attrs: [
-                    {name: 'at', value: 1, modDate: 0},
-                    {name: 'other', value: 'this is a value', modDate: 0}
-                ]},
-                {_id: {id: 'eB', servicePath: DEFAULT_SUBSERVICE, type: 'type e2'}, attrs: [
-                    {name: 'at', value: 2, modDate: Date.now() / 1000 - 30 * 60}
-                ]},
-                {_id: {id: 'eC', servicePath: DEFAULT_SUBSERVICE, type: 'type e3'}, attrs: [
-                    {name: 'at', value: 3, modDate: -1}
-                ]}
+                {
+                    _id: {id: 'eA', servicePath: DEFAULT_SUBSERVICE, type: 'type e1'},
+                    attrs: {
+                        'at': {value: 1, modDate: 0},
+                        'other': {value: 'this is a value', modDate: 0}
+                    }
+                },
+                {
+                    _id: {id: 'eB', servicePath: DEFAULT_SUBSERVICE, type: 'type e2'},
+                    attrs: {
+                        'at': {value: 2, modDate: Date.now() / 1000 - 30 * 60}
+                    }
+                },
+                {
+                    _id: {id: 'eC', servicePath: DEFAULT_SUBSERVICE, type: 'type e3'},
+                    attrs: {
+                        'at': {value: 3, modDate: -1}
+                    }
+                }
             ],
             checkInterval = 1,
             rule = utilsT.loadExample('./test/data/no_signal/generic_nonsignal.json');
+
         utilsT.getConfig().sms.URL = util.format('http://localhost:%s', utilsT.fakeHttpServerPort);
         this.timeout(2 * checkInterval * 60e3);
         it('should return silent entities', function(done) {


### PR DESCRIPTION
Use current Orion DB model for no-signal rules

```attrs``` field is an object with a field for each attribute and not an array of objects  with a field ```name``` and ```value```

@fgalan 