### PR TITLE
Add to doc limitations for service and subservice values 

### DIFF
--- a/documentation/api.md
+++ b/documentation/api.md
@@ -15,6 +15,15 @@ All HTTP request must have  `application/json` as MIME type. Responses are `appl
 
 Every request should send a field header for the service (`Fiware-Service`) and the subservice (`Fiware-ServicePath`) it refers to.
 
+For service and servicepath only alphanumeric and underscore characters are allowed.
+
+The servicepath is a set of scopes separated by "/" and has the following limitations:
+* each scope must start with "/"
+* 10 maximum scope levels in a path
+* 50 maximum characters in each level, only alphanum and underscore allowed
+* Empty scopes are not allowed, at least it has to have length 1 (excluding the "/")
+
+Fiware-ServicePath is an optional header. It is assumed that requests without Fiware-ServicePath belongs to a root scope "/" implicitely. 
 
 ### Notifications
 | Method | Path | Description|

--- a/documentation/api.md
+++ b/documentation/api.md
@@ -25,6 +25,8 @@ The servicepath is a set of scopes separated by "/" and has the following limita
 
 Fiware-ServicePath is an optional header. It is assumed that requests without Fiware-ServicePath belongs to a root scope "/" implicitely. 
 
+Internally to the CEP, scopes do not have a special meaning, so the entire servicepath string is used as a unit, and no operation of CEP takes into account a particular scope inside servicepath. Note this is the current behaviour, although it could change in the future to align more closely to how Orion uses service path (i.e. in a hierarchical way)
+
 ### Notifications
 | Method | Path | Description|
 | ------ |:-----|-----------|


### PR DESCRIPTION
@fgalan 

closes #206 

Name restrictions were documented already [plain rules](https://github.com/telefonicaid/perseo-fe/blob/master/documentation/plain_rules.md#plain-rules)

Service and subservience are documented by this PR