### PR TITLE
FIX Esper version reference in the documentation

### DIFF
--- a/documentation/plain_rules.md
+++ b/documentation/plain_rules.md
@@ -31,7 +31,7 @@ The field `action` can be also an array of "actions", objects with the same stru
 ## EPL text
 The field ```text``` of the rule must be a valid EPL statement and additionally must honor several restrictions to match expectations of perseo and perseo-core.
 
-EPL is documented in [Esper website](http://www.espertech.com/esper/esper-documentation), in particular [version 5.5.0](http://esper.espertech.com/release-5.5.0/esper-reference/html/index.html).
+EPL is documented in [Esper website](http://www.espertech.com/esper/esper-documentation), in particular [version 6.1.0](http://esper.espertech.com/release-6.1.0/esper-reference/html/index.html).
 
 A EPL statement to use with perseo could be:
 


### PR DESCRIPTION
It seems the reference to Esper documentation is not coherent with the version currently used by Perseo Core. This PR should fix it.

@cblanco could you confirm and aprove this PR, pls? Thanks!