### PR TITLE
Initial set-up for ReadtheDocs documentation for Perseo Front End.

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -1,4 +1,4 @@
-# Perseo-FE (EPL server)
+# Perseo-FE
 
 [![FIWARE Processing](https://nexus.lab.fiware.org/static/badges/chapters/processing.svg)](https://www.fiware.org/developers/catalogue/)
 [![](https://nexus.lab.fiware.org/repository/raw/public/badges/stackoverflow/fiware.svg)](https://stackoverflow.com/questions/tagged/fiware)

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -1,0 +1,5 @@
+# Perseo-FE (EPL server)
+
+[![FIWARE Processing](https://nexus.lab.fiware.org/static/badges/chapters/processing.svg)](https://www.fiware.org/developers/catalogue/)
+[![](https://nexus.lab.fiware.org/repository/raw/public/badges/stackoverflow/fiware.svg)](https://stackoverflow.com/questions/tagged/fiware)
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Perseo Front End
 site_url: https://fiware-perseo-fe.readthedocs.org
 repo_url: https://github.com/telefonicaid/perseo-fe.git
-site_description: Perseo-Front End (EPL server)
+site_description: Perseo-Front End
 docs_dir: documentation
 site_dir: html
 markdown_extensions: [toc,fenced_code]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,27 @@
+site_name: Perseo Front End
+site_url: https://fiware-perseo-fe.readthedocs.org
+repo_url: https://github.com/telefonicaid/perseo-fe.git
+site_description: Perseo-Front End (EPL server)
+docs_dir: documentation
+site_dir: html
+markdown_extensions: [toc,fenced_code]
+use_directory_urls: false
+theme: readthedocs
+extra_css: ["https://fiware.org/style/fiware_readthedocs.css", "https://www.fiware.org/style/fiware_readthedocs_processing.css"]
+
+pages:
+  - 'Home': 'index.md' 
+  - 'Architecture': 'architecture.md'
+  - 'Installation & Administration Manual':
+      - 'Introduction': 'admin.md'
+      - 'Configuration': 'configuration.md'
+      - 'Deployment': 'deployment.md'
+      - 'Logs': 'logs.md'
+  - 'User Guide':
+      - 'Plain Rules': 'plain_rules.md'
+      - 'Models': 'models.md'
+      - 'Actions': 'pep_actions.md'
+      - 'API': 'api.md'
+      - 'Metrics API': 'metrics_api.md'
+      - 'Errors': 'errors.md'
+


### PR DESCRIPTION
- Please create a project on readthedocs called fiware-perseo-fe and point to this repository.
- Includes standard CSS and badges.
- Just a dump of existing documentation but with CSS styling.