### PR TITLE
Add code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,7 @@ before_install:
 
 before_script:
  - npm run lint
+
+after_script: 
+  - npm run test:coveralls
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [![FIWARE Processing](https://nexus.lab.fiware.org/static/badges/chapters/processing.svg)](https://www.fiware.org/developers/catalogue/)
 [![License: APGL](https://img.shields.io/github/license/telefonicaid/perseo-fe.svg)](https://opensource.org/licenses/AGPL-3.0)
+<br/>
+[![Build badge](https://img.shields.io/travis/telefonicaid/perseo-fe.svg)](https://travis-ci.org/telefonicaid/perseo-fe/)
+[![Coverage Status](https://coveralls.io/repos/github/telefonicaid/perseo-fe/badge.svg?branch=master)](https://coveralls.io/github/telefonicaid/perseo-fe?branch=master)
 ![Status](https://nexus.lab.fiware.org/static/badges/statuses/perseo.svg)
 
 

--- a/package.json
+++ b/package.json
@@ -24,9 +24,11 @@
     "test:watch": "npm run test -- -w ./lib",
     "lint": "jshint lib/ --config .jshintrc && jshint test/ --config test/.jshintrc",
     "test:coverage": "istanbul cover _mocha -- --recursive 'test/**/*.js' --reporter spec --exit",
+    "test:coveralls": "npm run test:coverage && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
     "watch": "watch 'npm test && npm run lint' ./lib ./test"
   },
   "devDependencies": {
+    "coveralls": "~3.0.2",
     "istanbul": "~0.4.5",
     "jshint": "~2.9.6",
     "mocha": "5.2.0",


### PR DESCRIPTION
Expose Code Coverage results to Coveralls. Runs `npm test:coverage` after the unit tests and then sends the results to [coveralls](https://coveralls.io)

the repo needs to be exposed on coveralls as well (obviously) - see https://coveralls.io/repos/new

- SHOULD requirement from TSC