### PR TITLE
allow multiple to in sms action

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
+- Allow SMS actions with multiple phone destinations (#337)
 - Upgrade from node:8.12.0-slim to node:8.16.0-slim as base image in Dockerfile

--- a/documentation/plain_rules.md
+++ b/documentation/plain_rules.md
@@ -145,7 +145,8 @@ Sends a SMS to a number set as an action parameter with the body of the message 
     }
 ```
 
-The field `parameters` include a field `to` with the number to send the message to.
+The field `parameters` include a field `to` with the number, or numbers separated by whiestpace charaters, to send the
+message to.
 
 The `template` and `to` fields perform [attribute substitution](#string-substitution-syntax).
 

--- a/lib/models/smsAction.js
+++ b/lib/models/smsAction.js
@@ -35,11 +35,22 @@ function buildSMSOptions(action, event) {
         to: myutils.expandVar(action.parameters.to, event)
     };
 }
+
+function buildTo(to) {
+    const splitChar = ' ';
+    var tos = to.split(splitChar);
+    var r = [];
+    tos.forEach(function(dest) {
+        r.push('tel:' + dest);
+    });
+    return r;
+}
+
 function doIt(action, event, callback) {
     try {
         var options, msg;
         options = buildSMSOptions(action, event);
-        msg = { to: ['tel:' + options.to], message: options.text, from: config.sms.from };
+        msg = { to: buildTo(options.to), message: options.text, from: config.sms.from };
 
         metrics.IncMetrics(event.service, event.subservice, metrics.actionSMS);
 

--- a/test/acceptance/integration/Rules/EPL/epl_create_rules.feature
+++ b/test/acceptance/integration/Rules/EPL/epl_create_rules.feature
@@ -71,6 +71,21 @@ Feature: Append a new rule in Perseo manager
     Then I receive an "200" http code in rules request
     And Validate that rule name is created successfully in db
 
+  @happy_path
+  Scenario: Append a sms multiple rule in Perseo manager
+    # Gen EPL
+    Given an EPL sentence with name "sms_rule"
+    And the entity_type "Room" for the EPL
+    And the attributes for the EPL
+      | attribute_id | attribute_value_type | attribute_operation | attribute_value |
+      | temperature  | float                | >                   | 1.5             |
+    And generate the epl sentence with the data defined before
+    # Create the Rule
+    And set the sms action with text "the new temperature is ${temperature}" and number "666999666 777777"
+    And with the epl generated and the action, append a new rule in perseo with name "sms_rule"
+    # Validations
+    Then I receive an "200" http code in rules request
+    And Validate that rule name is created successfully in db
 
   @happy_path
   Scenario: Append a post rule in Perseo manager


### PR DESCRIPTION
issue: https://github.com/telefonicaid/perseo-fe/issues/337
Current implementation uses whitespace as split number separator( i.e.: `+346666666 +347777777 +359999999`)
- [x] Backward compatible
- [x] Tested
- [x] Update Doc
- [x] Update tests