### PR TITLE
FIX example in doc

### DIFF
--- a/documentation/plain_rules.md
+++ b/documentation/plain_rules.md
@@ -11,11 +11,15 @@ The “anatomy” of a rule is as follows
     "name": "blood_rule_update",
     "text": "select *, *, ev.BloodPressure? as Pressure, ev.id? as Meter from pattern [every ev=iotEvent(cast(cast(BloodPressure?,String),float)>1.5 and type=\"BloodMeter\")]",
     "action": {
-        "type": "update",
+        "type": "update",        
         "parameters": {
-            "name": "abnormal",
-            "value": "true",
-            "type": "boolean"
+            "attributes": [
+                {
+                    "name": "abnormal",
+                    "value": "true",
+                    "type": "boolean"
+                }
+            ]
         }
     }
 }

--- a/documentation/plain_rules.md
+++ b/documentation/plain_rules.md
@@ -11,7 +11,7 @@ The “anatomy” of a rule is as follows
     "name": "blood_rule_update",
     "text": "select *, *, ev.BloodPressure? as Pressure, ev.id? as Meter from pattern [every ev=iotEvent(cast(cast(BloodPressure?,String),float)>1.5 and type=\"BloodMeter\")]",
     "action": {
-        "type": "update",        
+        "type": "update",
         "parameters": {
             "attributes": [
                 {


### PR DESCRIPTION
Looking to https://github.com/telefonicaid/perseo-fe/blob/master/documentation/plain_rules.md#update-attribute-action, the current example doesn't match the parameters specification, as name/type/value cannot be used directly (they has to be in an object inside the attributes array, as far as I understand)