### PR TITLE
Do not cast using NGSIv2 types in updateAction (version 2)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+- Disable automatic cast for NGSIv2 types
 - Refactor updateAction doItWithToken to include version 1 and 2
 - Add missed correlatorid headers in updateAction with NGSIv2
 - Set default version to 2 (NGSIv2) for updateAction by default

--- a/bin/perseo
+++ b/bin/perseo
@@ -72,8 +72,8 @@ function loadConfiguration() {
         'PERSEO_SMPP_FROM',
         'PERSEO_SMPP_ENABLED',
         'PERSEO_NOTICES_PATH',
-        'PERSEO_RULES_PATH'
-
+        'PERSEO_RULES_PATH',
+        'PERSEO_CAST_TYPES'
     ];
 
     for (var i = 0; i < environmentValues.length; i++) {
@@ -154,6 +154,7 @@ function loadConfiguration() {
     config.smpp.enabled = process.env.PERSEO_SMPP_ENABLED || config.smpp.enabled;
     config.endpoint.noticesPath = process.env.PERSEO_NOTICES_PATH || config.endpoint.noticesPath;
     config.endpoint.rulesPath = process.env.PERSEO_RULES_PATH || config.endpoint.rulesPath;
+    config.castTypes = process.env.PERSEO_CAST_TYPES || config.castTypes;
 }
 
 loadConfiguration();

--- a/config.js
+++ b/config.js
@@ -214,4 +214,9 @@ config.checkDB = {
  */
 config.restBase = null;
 
+/**
+ * Cast attribute values in updateAction using NGSIv2 types
+ */
+config.castTypes = false;
+
 module.exports = config;

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -50,8 +50,6 @@ The following table shows the environment variables available for Perseo configu
 | PERSEO_AUTHENTICATION_PASSWORD     | Password for the user to perform authentication                                            |
 | PERSEO_CAST_TYPE                   | Cast or not attribute values to expected type conform NGSIv2 (false by default)            |
 
-> > > > > > > Stashed changes
-
 ### Basic Configuration
 
 In order to have perseo running, there are several basic pieces of information to fill:

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -48,6 +48,9 @@ The following table shows the environment variables available for Perseo configu
 | PERSEO_AUTHENTICATION_PORT         | Port of the authentication endpoint                                                        |
 | PERSEO_AUTHENTICATION_USER         | User to perform authentication                                                             |
 | PERSEO_AUTHENTICATION_PASSWORD     | Password for the user to perform authentication                                            |
+| PERSEO_CAST_TYPE                   | Cast or not attribute values to expected type conform NGSIv2 (false by default)            |
+
+> > > > > > > Stashed changes
 
 ### Basic Configuration
 
@@ -101,5 +104,6 @@ Options for Authentication through PEP (for update action)
 -   `config.authentication.port`: port,
 -   `config.authentication.user`: provisioned user for CEP in Keystone
 -   `config.authentication.password`: provisioned password for CEP in Keystone
+-   `config.castTypes`: cast or not attribute values to expected type conform NGSIv2 (false by default)
 
 URL format for mongoDB could be found at `http://mongodb.github.io/node-mongodb-native/driver-articles/mongoclient.html`

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -48,7 +48,7 @@ The following table shows the environment variables available for Perseo configu
 | PERSEO_AUTHENTICATION_PORT         | Port of the authentication endpoint                                                        |
 | PERSEO_AUTHENTICATION_USER         | User to perform authentication                                                             |
 | PERSEO_AUTHENTICATION_PASSWORD     | Password for the user to perform authentication                                            |
-| PERSEO_CAST_TYPE                   | Cast or not attribute values to expected type conform NGSIv2 (false by default)            |
+| PERSEO_CAST_TYPE                   |  If true, enable attribute value casting based in NGSIv2 attribute types if true. If false (default), the JSON native type for the attribute value is used.            |
 
 ### Basic Configuration
 

--- a/lib/models/updateAction.js
+++ b/lib/models/updateAction.js
@@ -240,33 +240,34 @@ function processOptionParams(action, event) {
         // Metadata should be null or object
         let theMeta = attr.metadata;
 
-        // Do not cast using NGSIv2 types
-        //var date;
-
-        // switch (theType) {
-        //     case 'Text':
-        //         theValue = theValue.toString();
-        //         break;
-        //     case 'Number':
-        //         theValue = parseFloat(theValue);
-        //         break;
-        //     case 'Boolean':
-        //         if (typeof theValue === 'string') {
-        //             theValue = theValue.toLowerCase().trim() === 'true';
-        //         }
-        //         break;
-        //     case 'DateTime':
-        //         if (parseInt(theValue).toString() === theValue) {
-        //             // Parse String with number (timestamp__ts in Perseo events)
-        //             theValue = parseInt(theValue);
-        //         }
-        //         date = new Date(theValue);
-        //         theValue = isNaN(date.getTime()) ? theValue : date.toISOString();
-        //         break;
-        //     case 'None':
-        //         theValue = null;
-        //         break;
-        // }
+        if (config.castTypes) {
+            // Cast using NGSIv2 types
+            var date;
+            switch (theType) {
+                case 'Text':
+                    theValue = theValue.toString();
+                    break;
+                case 'Number':
+                    theValue = parseFloat(theValue);
+                    break;
+                case 'Boolean':
+                    if (typeof theValue === 'string') {
+                        theValue = theValue.toLowerCase().trim() === 'true';
+                    }
+                    break;
+                case 'DateTime':
+                    if (parseInt(theValue).toString() === theValue) {
+                        // Parse String with number (timestamp__ts in Perseo events)
+                        theValue = parseInt(theValue);
+                    }
+                    date = new Date(theValue);
+                    theValue = isNaN(date.getTime()) ? theValue : date.toISOString();
+                    break;
+                case 'None':
+                    theValue = null;
+                    break;
+            }
+        }
         var key = myutils.expandVar(attr.name, event);
         changes[key] = {
             value: theValue,
@@ -300,33 +301,35 @@ function processUpdateOptionParams(action, entity) {
 
         // Metadata should be null or object
         let theMeta = attr.metadata;
-        // Do not cast using NGSIv2 types
-        //var date;
 
-        // switch (theType) {
-        //     case 'Text':
-        //         theValue = theValue.toString();
-        //         break;
-        //     case 'Number':
-        //         theValue = parseFloat(theValue);
-        //         break;
-        //     case 'Boolean':
-        //         if (typeof theValue === 'string') {
-        //             theValue = theValue.toLowerCase().trim() === 'true';
-        //         }
-        //         break;
-        //     case 'DateTime':
-        //         if (parseInt(theValue).toString() === theValue) {
-        //             // Parse String with number (timestamp__ts in Perseo events)
-        //             theValue = parseInt(theValue);
-        //         }
-        //         date = new Date(theValue);
-        //         theValue = isNaN(date.getTime()) ? theValue : date.toISOString();
-        //         break;
-        //     case 'None':
-        //         theValue = null;
-        //         break;
-        // }
+        if (config.castTypes) {
+            // Cast using NGSIv2 types
+            var date;
+            switch (theType) {
+                case 'Text':
+                    theValue = theValue.toString();
+                    break;
+                case 'Number':
+                    theValue = parseFloat(theValue);
+                    break;
+                case 'Boolean':
+                    if (typeof theValue === 'string') {
+                        theValue = theValue.toLowerCase().trim() === 'true';
+                    }
+                    break;
+                case 'DateTime':
+                    if (parseInt(theValue).toString() === theValue) {
+                        // Parse String with number (timestamp__ts in Perseo events)
+                        theValue = parseInt(theValue);
+                    }
+                    date = new Date(theValue);
+                    theValue = isNaN(date.getTime()) ? theValue : date.toISOString();
+                    break;
+                case 'None':
+                    theValue = null;
+                    break;
+            }
+        }
         var key = attr.name;
         options[key] = {
             value: theValue,

--- a/lib/models/updateAction.js
+++ b/lib/models/updateAction.js
@@ -270,9 +270,10 @@ function processOptionParams(action, event) {
         let theType = myutils.expandVar(attr.type, event);
         // Metadata should be null or object
         let theMeta = attr.metadata;
-        var date;
 
         // Do not cast using NGSIv2 types
+        //var date;
+
         // switch (theType) {
         //     case 'Text':
         //         theValue = theValue.toString();

--- a/lib/models/updateAction.js
+++ b/lib/models/updateAction.js
@@ -272,30 +272,31 @@ function processOptionParams(action, event) {
         let theMeta = attr.metadata;
         var date;
 
-        switch (theType) {
-            case 'Text':
-                theValue = theValue.toString();
-                break;
-            case 'Number':
-                theValue = parseFloat(theValue);
-                break;
-            case 'Boolean':
-                if (typeof theValue === 'string') {
-                    theValue = theValue.toLowerCase().trim() === 'true';
-                }
-                break;
-            case 'DateTime':
-                if (parseInt(theValue).toString() === theValue) {
-                    // Parse String with number (timestamp__ts in Perseo events)
-                    theValue = parseInt(theValue);
-                }
-                date = new Date(theValue);
-                theValue = isNaN(date.getTime()) ? theValue : date.toISOString();
-                break;
-            case 'None':
-                theValue = null;
-                break;
-        }
+        // Do not cast using NGSIv2 types
+        // switch (theType) {
+        //     case 'Text':
+        //         theValue = theValue.toString();
+        //         break;
+        //     case 'Number':
+        //         theValue = parseFloat(theValue);
+        //         break;
+        //     case 'Boolean':
+        //         if (typeof theValue === 'string') {
+        //             theValue = theValue.toLowerCase().trim() === 'true';
+        //         }
+        //         break;
+        //     case 'DateTime':
+        //         if (parseInt(theValue).toString() === theValue) {
+        //             // Parse String with number (timestamp__ts in Perseo events)
+        //             theValue = parseInt(theValue);
+        //         }
+        //         date = new Date(theValue);
+        //         theValue = isNaN(date.getTime()) ? theValue : date.toISOString();
+        //         break;
+        //     case 'None':
+        //         theValue = null;
+        //         break;
+        // }
         var key = myutils.expandVar(attr.name, event);
         changes[key] = {
             value: theValue,

--- a/lib/models/updateAction.js
+++ b/lib/models/updateAction.js
@@ -331,32 +331,33 @@ function processUpdateOptionParams(action, entity) {
         let theType = attr.name in entity ? entity[attr.name].type : attr.type;
         // Metadata should be null or object
         let theMeta = attr.metadata;
-        var date;
+        // Do not cast using NGSIv2 types
+        //var date;
 
-        switch (theType) {
-            case 'Text':
-                theValue = theValue.toString();
-                break;
-            case 'Number':
-                theValue = parseFloat(theValue);
-                break;
-            case 'Boolean':
-                if (typeof theValue === 'string') {
-                    theValue = theValue.toLowerCase().trim() === 'true';
-                }
-                break;
-            case 'DateTime':
-                if (parseInt(theValue).toString() === theValue) {
-                    // Parse String with number (timestamp__ts in Perseo events)
-                    theValue = parseInt(theValue);
-                }
-                date = new Date(theValue);
-                theValue = isNaN(date.getTime()) ? theValue : date.toISOString();
-                break;
-            case 'None':
-                theValue = null;
-                break;
-        }
+        // switch (theType) {
+        //     case 'Text':
+        //         theValue = theValue.toString();
+        //         break;
+        //     case 'Number':
+        //         theValue = parseFloat(theValue);
+        //         break;
+        //     case 'Boolean':
+        //         if (typeof theValue === 'string') {
+        //             theValue = theValue.toLowerCase().trim() === 'true';
+        //         }
+        //         break;
+        //     case 'DateTime':
+        //         if (parseInt(theValue).toString() === theValue) {
+        //             // Parse String with number (timestamp__ts in Perseo events)
+        //             theValue = parseInt(theValue);
+        //         }
+        //         date = new Date(theValue);
+        //         theValue = isNaN(date.getTime()) ? theValue : date.toISOString();
+        //         break;
+        //     case 'None':
+        //         theValue = null;
+        //         break;
+        // }
         var key = attr.name;
         options[key] = {
             value: theValue,

--- a/test/unit/updateAction.js
+++ b/test/unit/updateAction.js
@@ -50,12 +50,12 @@ var action1 = {
             {
                 name: 'textNumberLit',
                 type: 'Text',
-                value: '666'
+                value: 666
             },
             {
                 name: 'textBoolLit',
                 type: 'Text',
-                value: 'false'
+                value: false
             },
             {
                 name: 'textObjLit',

--- a/test/unit/updateAction.js
+++ b/test/unit/updateAction.js
@@ -50,7 +50,7 @@ var action1 = {
             {
                 name: 'textNumberLit',
                 type: 'Text',
-                value: 666
+                value: '666'
             },
             {
                 name: 'textBoolLit',
@@ -212,15 +212,16 @@ var expectedChanges = {
                 type: 'Text'
             },
             textBoolLit: {
-                value: 'false',
+                value: false,
                 type: 'Text'
             },
             textNumberLit: {
-                value: '666',
+                value: 666,
                 type: 'Text'
             },
             textObjLit: {
-                value: '[object Object]',
+                value: { a: 1, b: 2 },
+                //value: '[object Object]',
                 type: 'Text'
             },
             refNone: {
@@ -228,7 +229,7 @@ var expectedChanges = {
                 type: 'None'
             },
             refNone2: {
-                value: null,
+                value: 123,
                 type: 'None'
             },
             refNone3: {
@@ -253,7 +254,7 @@ var expectedChanges = {
                 type: 'Boolean'
             },
             isBool5: {
-                value: false,
+                value: 'other',
                 type: 'Boolean'
             },
             isBool6: {
@@ -293,11 +294,11 @@ var expectedChanges = {
                 type: 'DateTime'
             },
             lastchange2: {
-                value: '2019-01-30T10:11:00.657Z',
+                value: 1548843060657,
                 type: 'DateTime'
             },
             lastchange3: {
-                value: '2019-01-30T10:13:49.832Z',
+                value: 1548843229832,
                 type: 'DateTime'
             }
         }

--- a/test/unit/updateAction.js
+++ b/test/unit/updateAction.js
@@ -221,7 +221,6 @@ var expectedChanges = {
             },
             textObjLit: {
                 value: { a: 1, b: 2 },
-                //value: '[object Object]',
                 type: 'Text'
             },
             refNone: {

--- a/test/unit/updateAction.js
+++ b/test/unit/updateAction.js
@@ -55,7 +55,7 @@ var action1 = {
             {
                 name: 'textBoolLit',
                 type: 'Text',
-                value: false
+                value: 'false'
             },
             {
                 name: 'textObjLit',
@@ -106,7 +106,7 @@ var action1 = {
             {
                 name: 'isBool2',
                 type: 'Boolean',
-                value: 'TRUE'
+                value: 'true'
             },
             {
                 name: 'isBool3',
@@ -116,7 +116,7 @@ var action1 = {
             {
                 name: 'isBool4',
                 type: 'Boolean',
-                value: 'False'
+                value: 'false'
             },
             {
                 name: 'isBool5',
@@ -156,7 +156,7 @@ var action1 = {
             {
                 name: 'refNone',
                 type: '${refNoneType}',
-                value: 'futureNull'
+                value: null
             },
             {
                 name: 'refNone2',
@@ -182,7 +182,7 @@ var event1 = {
     addressLocality: 'Stockholm',
     laststatus: 'allright',
     powerState: 'on',
-    stringDate: '2018-12-05T11:31:39.00Z',
+    stringDate: '2018-12-05T11:31:39.000Z',
     stringDateMs: '1548843060657',
     numberDateMs: 1548843229832,
     subservice: '/',


### PR DESCRIPTION
Currently there are some automatic cast about types:
- Number
- Text
- Booleam
- None
- DateTime


What do we want?
Currently updateAction in version 2 is trying to cast (after expandVars) to NGSIv2 types like:

```javascript
var changes = {};
    action.parameters.attributes.forEach(function(attr) {
        // Direct value for Text, DateTime, and others. Apply expandVar for strings
        let theValue = myutils.expandVar(attr.value, event, true);
        let theType = myutils.expandVar(attr.type, event);
        // Metadata should be null or object
        let theMeta = attr.metadata;
        var date;
        switch (theType) {
             case 'Text':
                 theValue = theValue.toString();
                 break;
             case 'Number':
                 theValue = parseFloat(theValue);
                 break;
             case 'Boolean':
                 if (typeof theValue === 'string') {
                     theValue = theValue.toLowerCase().trim() === 'true';
                 }
                 break;
             case 'DateTime':
                 if (parseInt(theValue).toString() === theValue) {
                     // Parse String with number (timestamp__ts in Perseo events)
                     theValue = parseInt(theValue);
                 }
                 date = new Date(theValue);
                 theValue = isNaN(date.getTime()) ? theValue : date.toISOString();
                 break;
             case 'None':
                 theValue = null;
                 break;
         }
        var key = myutils.expandVar(attr.name, event);
        changes[key] = {
            value: theValue,
            type: theType
        };
```