### PR TITLE
revert default version for updateAction

### DIFF
--- a/documentation/plain_rules.md
+++ b/documentation/plain_rules.md
@@ -158,8 +158,9 @@ This substitution can be used in the following fields:
 Attribute value of `update` action and template of `post` action are expanded to numerical, boolean or JSON stringyfied
 values instead of string values when is possible. For example, if we have `{"a": "${x}"}`:
 
-* If the value of attribute `x` is `42` then it will expand do `{"a": 42}` and not to `{"a": "42"}`
-* If the value of attribute `x` is `{"hello": "world"}` then it will expand to `{"a": "{\"hello\":\"world\"}"}` (expand to native JSON, i.e. `{"a": {"hello": "world"}}`, is not supported)
+-   If the value of attribute `x` is `42` then it will expand do `{"a": 42}` and not to `{"a": "42"}`
+-   If the value of attribute `x` is `{"hello": "world"}` then it will expand to `{"a": "{\"hello\":\"world\"}"}`
+    (expand to native JSON, i.e. `{"a": {"hello": "world"}}`, is not supported)
 
 ### SMS action
 
@@ -210,7 +211,7 @@ the Perseo configuration). The `parameters` map includes the following fields:
 -   type: optional, the type of the entity which attribute is to be updated (by default the type of the entity that
     triggers the rule is usedi.e. `${type}`)
 -   version: optional, The NGSI version for the update action. Set this attribute to `2` or `"2"` if you want to use
-    NGSv2 format. `2` by default.
+    NGSv2 format. `1` by default.
 -   isPattern: optional, `false` by default. (Only for NGSIv1. If `version` is set to 2, this attribute will be ignored)
 -   attributes: _mandatory_, array of target attributes to update. Each element of the array must contain the fields
     -   **name**: _mandatory_, attribute name to set
@@ -220,7 +221,9 @@ the Perseo configuration). The `parameters` map includes the following fields:
 -   actionType: optional, type of CB action: APPEND or UPDATE. By default is APPEND.
 -   trust: optional, trust token for getting an access token from Auth Server which can be used to get to a Context
     Broker behind a PEP.
--   filter: optional, a NGSIv2 filter. If provided then updateAction is done over result of query. This overrides the `id` field (in other words, if you use `filter` then `id` field is ignored, in fact you should not use `id` and `filter` in the same rule). Needs `version: 2` option (if `version` is `1` the filter is ignored).
+-   filter: optional, a NGSIv2 filter. If provided then updateAction is done over result of query. This overrides the
+    `id` field (in other words, if you use `filter` then `id` field is ignored, in fact you should not use `id` and
+    `filter` in the same rule). Needs `version: 2` option (if `version` is `1` the filter is ignored).
 
 NGSIv1 example:
 
@@ -283,8 +286,8 @@ NGSIv2 example:
 ```
 
 When using NGSIv2 in the update actions, the value field perform [string substitution](#string-substitution-syntax). If
-`value` is a String, Perseo will try cast value to number, boolean or null (without paying attention to the attribute type). If the casting fails then String is used.
-_`Boolean`_ and _`None`_ types.
+`value` is a String, Perseo will try cast value to number, boolean or null (without paying attention to the attribute
+type). If the casting fails then String is used. _`Boolean`_ and _`None`_ types.
 
 **Data Types for NGSIv2:**
 
@@ -617,38 +620,40 @@ For example: The metadata in an event/notice like
 
 ```json
 {
-  "subscriptionId" : "51c04a21d714fb3b37d7d5a7",
-  "originator" : "localhost",
-  "contextResponses" : [
-    {
-      "contextElement" : {
-        "attributes" : [
-          {
-            "name" : "BloodPressure",
-            "type" : "centigrade",
-            "value" : "2",
-            "metadatas": [{
-              "crs": {
-                "value": {"system": "WGS84"}
-              }
-            }]            
-          },
-         {
-            "name" : "TimeInstant",
-            "type" : "urn:x-ogc:def:trs:IDAS:1.0:ISO8601",
-            "value" : "2014-04-29T13:18:05Z"
-          }
-        ],
-        "type" : "BloodMeter",
-        "isPattern" : "false",
-        "id" : "bloodm1"
-      },
-      "statusCode" : {
-        "code" : "200",
-        "reasonPhrase" : "OK"
-      }
-    }
-  ]
+    "subscriptionId": "51c04a21d714fb3b37d7d5a7",
+    "originator": "localhost",
+    "contextResponses": [
+        {
+            "contextElement": {
+                "attributes": [
+                    {
+                        "name": "BloodPressure",
+                        "type": "centigrade",
+                        "value": "2",
+                        "metadatas": [
+                            {
+                                "crs": {
+                                    "value": { "system": "WGS84" }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "TimeInstant",
+                        "type": "urn:x-ogc:def:trs:IDAS:1.0:ISO8601",
+                        "value": "2014-04-29T13:18:05Z"
+                    }
+                ],
+                "type": "BloodMeter",
+                "isPattern": "false",
+                "id": "bloodm1"
+            },
+            "statusCode": {
+                "code": "200",
+                "reasonPhrase": "OK"
+            }
+        }
+    ]
 }
 ```
 

--- a/lib/models/updateAction.js
+++ b/lib/models/updateAction.js
@@ -449,7 +449,7 @@ function doRequestV2(action, event, token, callback) {
         logger.debug('entity to update: %j', changes);
         // FIXME: createEntity with upsert true is always updating entity,
         // but is not using params.actionType (append or update)
-        // Maybe other methods like v2.updateEntityAttributes is more proper ?
+        // Maybe other methods like v2.updateEntityAttributes are more proper ?
         connection.v2.createEntity(changes, { upsert: true }).then(
             (response) => {
                 // response.correlator transaction id associated with the server response

--- a/lib/models/updateAction.js
+++ b/lib/models/updateAction.js
@@ -447,7 +447,8 @@ function doRequestV2(action, event, token, callback) {
         var changes = processOptionParams(action, event);
         metrics.IncMetrics(event.service, event.subservice, metrics.actionEntityUpdate);
         logger.debug('entity to update: %j', changes);
-        // FIXME: createEntity with upsert true is always updating entity, but is not using params.actionType (append or update)
+        // FIXME: createEntity with upsert true is always updating entity,
+        // but is not using params.actionType (append or update)
         // Maybe other methods like v2.updateEntityAttributes is more proper ?
         connection.v2.createEntity(changes, { upsert: true }).then(
             (response) => {

--- a/lib/models/updateAction.js
+++ b/lib/models/updateAction.js
@@ -447,6 +447,8 @@ function doRequestV2(action, event, token, callback) {
         var changes = processOptionParams(action, event);
         metrics.IncMetrics(event.service, event.subservice, metrics.actionEntityUpdate);
         logger.debug('entity to update: %j', changes);
+        // FIXME: createEntity with upsert true is always updating entity, but is not using params.actionType (append or update)
+        // Maybe other methods like v2.updateEntityAttributes is more proper ?
         connection.v2.createEntity(changes, { upsert: true }).then(
             (response) => {
                 // response.correlator transaction id associated with the server response
@@ -507,7 +509,7 @@ function doItWithToken(action, event, version, callback) {
 
 function doIt(action, event, callback) {
     try {
-        if (action.parameters.version !== '1' && action.parameters.version !== 1) {
+        if (action.parameters.version === '2' || action.parameters.version === 2) {
             if (action.parameters.trust) {
                 return doItWithToken(action, event, 2, callback);
             } else {


### PR DESCRIPTION
revert previous PR https://github.com/telefonicaid/perseo-fe/pull/375

Reason: The behavior of UpdaetAction is different if use version1 or version2 in action.parameter.version,  version2 is buggy:
updateAction version 2 is using createEntity [*] with upsert: true and not using updateAction (append or update)

[*] https://conwetlab.github.io/ngsijs/stable/NGSI.Connection.html#.%22v2.createEntity%22

Only UpdateAction with filter needs version 2 because is not using createEntity methods (and presumably is not buggy)