### PR TITLE
set default version 2 for updateAction

### DIFF
--- a/documentation/plain_rules.md
+++ b/documentation/plain_rules.md
@@ -211,7 +211,7 @@ the Perseo configuration). The `parameters` map includes the following fields:
 -   type: optional, the type of the entity which attribute is to be updated (by default the type of the entity that
     triggers the rule is usedi.e. `${type}`)
 -   version: optional, The NGSI version for the update action. Set this attribute to `2` or `"2"` if you want to use
-    NGSv2 format. `1` by default.
+    NGSv2 format. `2` by default.
 -   isPattern: optional, `false` by default. (Only for NGSIv1. If `version` is set to 2, this attribute will be ignored)
 -   attributes: _mandatory_, array of target attributes to update. Each element of the array must contain the fields
     -   **name**: _mandatory_, attribute name to set

--- a/lib/models/updateAction.js
+++ b/lib/models/updateAction.js
@@ -513,7 +513,7 @@ function doItWithToken(action, event, version, callback) {
 
 function doIt(action, event, callback) {
     try {
-        if (action.parameters.version === '2' || action.parameters.version === 2) {
+        if (action.parameters.version === '1' && action.parameters.version === 1) {
             if (action.parameters.trust) {
                 return doItWithToken(action, event, 2, callback);
             } else {

--- a/lib/models/updateAction.js
+++ b/lib/models/updateAction.js
@@ -513,7 +513,7 @@ function doItWithToken(action, event, version, callback) {
 
 function doIt(action, event, callback) {
     try {
-        if (action.parameters.version === '1' && action.parameters.version === 1) {
+        if (action.parameters.version !== '1' && action.parameters.version !== 1) {
             if (action.parameters.trust) {
                 return doItWithToken(action, event, 2, callback);
             } else {


### PR DESCRIPTION
issue https://github.com/telefonicaid/perseo-fe/issues/391

No CNR update is needed (already is updated)
- [ ] Tested in e2e CI