### PR TITLE
allow old format attributes

### DIFF
--- a/lib/models/updateAction.js
+++ b/lib/models/updateAction.js
@@ -225,6 +225,14 @@ function processOptionParams(action, event) {
     action.parameters.attributes = action.parameters.attributes || [];
 
     var changes = {};
+    // old format, with only one attribute to update
+    if (action.parameters.name) {
+        action.parameters.attributes.push({
+            name: action.parameters.name,
+            value: action.parameters.value,
+            type: action.parameters.attrType
+        });
+    }
     action.parameters.attributes.forEach(function(attr) {
         // Direct value for Text, DateTime, and others. Apply expandVar for strings
         let theValue = myutils.expandVar(attr.value, event, true);
@@ -396,7 +404,7 @@ function doRequestV2(action, event, token, callback) {
                 };
 
                 if (action.parameters.actionType !== undefined) {
-                    changes.actionType = action.parameters.actionType;
+                    options.actionType = myutils.expandVar(action.parameters.actionType, event);
                 }
 
                 if (response && response.results) {
@@ -449,7 +457,7 @@ function doRequestV2(action, event, token, callback) {
             entities: [processOptionParams(action, event)]
         };
         if (action.parameters.actionType !== undefined) {
-            changes.actionType = action.parameters.actionType;
+            changes.actionType = myutils.expandVar(action.parameters.actionType, event);
         }
         metrics.IncMetrics(event.service, event.subservice, metrics.actionEntityUpdate);
         logger.debug('entity to update: %j', changes);


### PR DESCRIPTION
related with https://github.com/telefonicaid/perseo-fe/pull/394 to allow VRs with version2

Similar of doRequest (v1):
https://github.com/telefonicaid/perseo-fe/blob/master/lib/models/updateAction.js#L87

```javascript
  if (action.parameters.name) {
        action.parameters.attributes.push({
            name: action.parameters.name,
            value: action.parameters.value,
            type: action.parameters.attrType
        });
}
```