### PR TITLE
Update mongodb in package.json

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
-- Upgrade mongodb dependency to 2.2.35
+- Upgrade mongodb dependency from ~2.2.31 to ~2.2.35
 - Include stripped (non flatten) data into event (#377)
 - Add: castType (PERSEO_CAST_TYPE) to enable NGSIv2 type based casting (default is to use JSON native types in values)
 - Add authentication config env vars (#349)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+- Upgrade mongodb dependency to 2.2.35
 - Include stripped (non flatten) data into event (#377)
 - Add: castType (PERSEO_CAST_TYPE) to enable NGSIv2 type based casting (default is to use JSON native types in values)
 - Add authentication config env vars (#349)

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "body-parser": "~1.18.2",
     "express": "~4.16.1",
     "logops": "2.1.0",
-    "mongodb": "2.2.35",
+    "mongodb": "~2.2.35",
     "ngsijs": "~1.2.1",
     "nodemailer": "~1.11.0",
     "nodemailer-smtp-transport": "~0.1.13",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "body-parser": "~1.18.2",
     "express": "~4.16.1",
     "logops": "2.1.0",
-    "mongodb": "~2.2.31",
+    "mongodb": "2.2.35",
     "ngsijs": "~1.2.1",
     "nodemailer": "~1.11.0",
     "nodemailer-smtp-transport": "~0.1.13",


### PR DESCRIPTION
iot-perseo-fe               | the server/replset/mongos options are deprecated, all their options are supported at the top level of the options object [poolSize,ssl,sslValidate,sslCA,sslCert,ciphers,ecdhCurve,sslKey,sslPass,sslCRL,autoReconnect,noDelay,keepAlive,connectTimeoutMS,family,socketTimeoutMS,reconnectTries,reconnectInterval,ha,haInterval,replicaSet,secondaryAcceptableLatencyMS,acceptableLatencyMS,connectWithNoPrimary,authSource,w,wtimeout,j,forceServerObjectId,serializeFunctions,ignoreUndefined,raw,bufferMaxEntries,readPreference,pkFactory,promiseLibrary,readConcern,maxStalenessSeconds,loggerLevel,logger,promoteValues,promoteBuffers,promoteLongs,domainsEnabled,keepAliveInitialDelay,checkServerIdentity,validateOptions,appname,auth]