### PR TITLE
Bump to node 10

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -3,3 +3,4 @@
   - express: from ~4.16.1 to ~4.16.4
   - request: from ~2.83.0 to 2.88.0
 - Hardening: MongoDB connection logic to avoid deprecated parameteres
+- Upgrade NodeJS version from 8.16.1 to 10.17.0 in Dockerfile due to Node 8 End-of-Life 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@
 # For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
 #
 
-FROM node:8.16.1-slim
+ARG NODE_VERSION=10.17.0-slim
+FROM node:${NODE_VERSION}
 
 MAINTAINER FIWARE Perseo Team. Telefónica I+D
 


### PR DESCRIPTION
Node 8 leaves LTS at the end of the year. The default node version should be switched to Node Dubnium for the upcoming December FIWARE 7.8.1 Patch release.