### PR TITLE
log checkNoSignal error using current context

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Log checkNoSignal error using current context

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-- Log checkNoSignal error using current context
+- Log checkNoSignal error using current context (#422)

--- a/lib/models/noSignal.js
+++ b/lib/models/noSignal.js
@@ -110,6 +110,9 @@ function checkNoSignal(period) {
     var list = nsRulesByInterval[period] || [];
     logger.debug(context, 'Executing no-signal handler for period of %d (%d rules)', period, list.length);
     list.forEach(function(nsrule) {
+        var currentContext = context;
+        currentContext.srv = nsrule[SERVICE];
+        currentContext.subsrv = nsrule[SUBSERVICE];
         entitiesStore.FindSilentEntities(
             nsrule[SERVICE],
             nsrule[SUBSERVICE],
@@ -122,8 +125,8 @@ function checkNoSignal(period) {
             },
             alertFunc.bind({}, nsrule),
             function(err, data) {
-                myutils.logErrorIf(err);
-                logger.debug(context, 'silent entities: ', data);
+                myutils.logErrorIf(err, currentContext);
+                logger.debug(currentContext, 'silent entities: ', data);
             }
         );
     });


### PR DESCRIPTION
related #422
These kind or logs, which could be relevant, are printing `op`, `srv` and `subsrv` in a wrong way:
```
perseo.log-20200123.gz:time=2020-01-22T12:17:42.724Z | lvl=ERROR | corr=n/a | trans=n/a | op=initialRefresh | comp=perseo-fe | srv=n/a | subsrv=n/a | msg= Collection entities does not exist. Currently in strict mode.
```