### PR TITLE
Task/use unique corr suffix

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
+- Use unique (by node) correlator_suffix to detect rule loops (#456)
 - Log checkNoSignal error using current context (#422)

--- a/lib/middleware/domain.js
+++ b/lib/middleware/domain.js
@@ -29,7 +29,8 @@ var domain = require('domain'),
     constants = require('../constants'),
     metrics = require('../models/metrics'),
     config = require('../../config'),
-    CORR_SUFFIX = '; perseocep=',
+    shortid = require('shortid'),
+    CORR_SUFFIX = '; node=' + shortid.generate() + ' ; perseocep=',
     MAX_INT_SAFE = (1 << 53) - 1,
     corrSequence = 0;
 

--- a/lib/middleware/domain.js
+++ b/lib/middleware/domain.js
@@ -30,7 +30,7 @@ var domain = require('domain'),
     metrics = require('../models/metrics'),
     config = require('../../config'),
     shortid = require('shortid'),
-    CORR_SUFFIX = '; node=' + shortid.generate() + ' ; perseocep=',
+    CORR_SUFFIX = '; node=' + shortid.generate() + '; perseocep=',
     MAX_INT_SAFE = (1 << 53) - 1,
     corrSequence = 0;
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "swagger-ui-express": "~4.1.1",
     "twitter": "~1.7.1",
     "utm-converter": "~0.1.1",
-    "uuid": "~1.4.2"
+    "uuid": "~1.4.2",
+    "shortid": "~2.3.0"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "twitter": "~1.7.1",
     "utm-converter": "~0.1.1",
     "uuid": "~1.4.2",
-    "shortid": "~2.3.0"
+    "shortid": "~2.2.15"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
issue https://github.com/telefonicaid/perseo-fe/issues/456
This PR extends correlator from this format:
```
corr=b6ab6d76-c0da-11ea-9688-fa163e83ea20; perseocep=1
```
to 
```
corr=b6ab6d76-c0da-11ea-9688-fa163e83ea20; node=23TplPdS; perseocep=1
```
that will be different in each instance of perseo-fe but keeps perseocep counter that could be also usefull for debuging 