### PR TITLE
avoid stop perseo after uncaught exception

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
+- Avoid stop perseo after uncaught exception
 - Use unique (by node) correlator_suffix to detect rule loops (#456)
 - Log checkNoSignal error using current context (#422)

--- a/bin/perseo
+++ b/bin/perseo
@@ -36,9 +36,6 @@ logger.format = logger.formatters.pipe;
 
 process.on('uncaughtException', function(ex){
     logger.fatal(context, 'uncaughtException: %s', ex.message || ex , ex.stack && ex.stack.split('\n').join(','));
-    logger.stream.write('',function(){
-        process.exit(-1);
-    });
 });
 
 function loadConfiguration() {


### PR DESCRIPTION
like iotagent-node-lib does by default ?
https://github.com/telefonicaid/iotagent-node-lib/blob/master/lib/fiware-iotagent-lib.js#L70
https://github.com/telefonicaid/iotagent-node-lib/blob/master/lib/fiware-iotagent-lib.js#L91