### PR TITLE
Fix dead links false positives on Markdown linter

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -184,13 +184,6 @@
       "weasel": false,
       "so": false,
       "thereIs": false
-    },
-    "no-dead-link": {
-       "ignoreRedirects": true,
-       "ignore": [
-          "mailto:*",
-          "https://oauth.net"
-      ]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "sinon-chai": "~3.2.0",
     "textlint": "~11.0.1",
     "textlint-rule-common-misspellings": "~1.0.1",
-    "textlint-rule-no-dead-link": "~4.4.1",
     "textlint-rule-terminology": "~1.1.30",
     "textlint-rule-write-good": "~1.6.2",
     "watch": "~1.0.2"


### PR DESCRIPTION
- Removed textlint no-dead-link from .textlintrc
- Removed textlint-rule-no-dead-link from package.json

Related with https://github.com/telefonicaid/iotagent-json/pull/515#issuecomment-736355544