### PR TITLE
empty smtp auth whem empty

### DIFF
--- a/bin/perseo
+++ b/bin/perseo
@@ -195,6 +195,9 @@ function loadConfiguration() {
     config.smtp.auth = config.smtp.auth || {};
     config.smtp.auth.user = process.env.PERSEO_SMTP_AUTH_USER || config.smtp.auth.user;
     config.smtp.auth.pass = process.env.PERSEO_SMTP_AUTH_PASS || config.smtp.auth.pass;
+    if (Object.keys(config.smtp.auth).length === 0) {
+        delete config.smtp.auth;
+    }
     if (process.env.PERSEO_SMTP_TLS_REJECTUNAUTHORIZED === 'true') {
         config.smtp.tls.rejectUnauthorized = true;
     } else if (process.env.PERSEO_SMTP_TLS_REJECTUNAUTHORIZED === 'false') {


### PR DESCRIPTION
reopens https://github.com/telefonicaid/perseo-fe/pull/516 due to https://github.com/telefonicaid/perseo-fe/pull/516#issuecomment-817522903 is starting with `config.smtp.auth` empty