### PR TITLE
upgrade nodemailer dep

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
 Update mongodb dep driver from 3.6.3 to 3.6.8
+Update nodemailer dep from 4.6.8 to 4.6.18

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
 Update mongodb dep driver from 3.6.3 to 3.6.8
-Update nodemailer dep from 6.4.8 to 4.6.18
+Update nodemailer dep from 6.4.8 to 6.4.18

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
 Update mongodb dep driver from 3.6.3 to 3.6.8
-Update nodemailer dep from 4.6.8 to 4.6.18
+Update nodemailer dep from 6.4.8 to 4.6.18

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "logops": "2.1.0",
     "mongodb": "3.6.8",
     "ngsijs": "~1.2.1",
-    "nodemailer": "6.4.8",
+    "nodemailer": "6.4.18",
     "nodemailer-smtp-transport": "~2.7.2",
     "request": "2.88.0",
     "shortid": "~2.2.15",


### PR DESCRIPTION
6.4.8 -> 6.4.18

Tested with  
    - PERSEO_SMTP_SECURE=false
    - PERSEO_SMTP_HOST=smtp.gmail.com
    - PERSEO_SMTP_PORT=587
    - PERSEO_SMTP_AUTH_USER=<user>
    - PERSEO_SMTP_AUTH_PASS=<pwd>
