### PR TITLE
Fix/return error 400 from perseo core instead of 500

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+FIx: return error 400 from perseo-core instead of 500 (#539)
 Update ngsijs dep from 1.2.1 to 1.3.0
 Fix: ngsiv2 initial notification does not include a list of subservices in servicePath header when is / (#527)
 Update mongodb dep driver from 3.6.3 to 3.6.8

--- a/lib/myutils.js
+++ b/lib/myutils.js
@@ -192,7 +192,7 @@ function requestHelperAux(method, options, withMetrics, callback) {
                     (body && body.error) || (body && JSON.stringify(body)) || response.statusCode
                 )
             );
-            localError.httpCode = 500;
+            localError.httpCode = respObj.code < 500 && respObj.code >= 400 ? respObj.code : 500;
             logErrorIf(localError, domain && domain.context);
             if (withMetrics && domain.context) {
                 metrics.IncMetrics(domain.context.srv, domain.context.subsrv, metrics.outgoingTransactionsErrors);

--- a/test/component/metrics/metrics_rules_test.js
+++ b/test/component/metrics/metrics_rules_test.js
@@ -31,7 +31,6 @@ var async = require('async'),
     metrics = require('../../../lib/models/metrics');
 
 describe('Metrics', function() {
-
     beforeEach(testEnv.commonBeforeEach);
     afterEach(testEnv.commonAfterEach);
 
@@ -39,35 +38,41 @@ describe('Metrics', function() {
         it('should increment correct rules', function(done) {
             var cases = utilsT.loadDirExamples('./test/data/good_rules');
             metrics.GetDecorated(true); // reset value
-            async.eachSeries(cases, function(c, callback) {
-                clients.PostRule(c.object, function(error, data) {
+            async.eachSeries(
+                cases,
+                function(c, callback) {
+                    clients.PostRule(c.object, function(error, data) {
+                        should.not.exist(error);
+                        data.should.have.property('statusCode', 200);
+                        return callback(null);
+                    });
+                },
+                function(error) {
+                    var m = metrics.GetDecorated(true),
+                        msub;
                     should.not.exist(error);
-                    data.should.have.property('statusCode', 200);
-                    return callback(null);
-                });
-            }, function(error) {
-                var m = metrics.GetDecorated(true), msub;
-                should.not.exist(error);
-                should.exists(m);
-                should.exists(m.services);
-                should.exists(m.services.unknownt);
-                should.exists(m.services.unknownt.subservices);
-                should.exists(m.services.unknownt.subservices['/']);
-                msub = m.services.unknownt.subservices['/'];
+                    should.exists(m);
+                    should.exists(m.services);
+                    should.exists(m.services.unknownt);
+                    should.exists(m.services.unknownt.subservices);
+                    should.exists(m.services.unknownt.subservices['/']);
+                    msub = m.services.unknownt.subservices['/'];
 
-                should.equal(m.services.unknownt.sum.ruleCreation, cases.length);
-                should.equal(m.services.unknownt.sum.okRuleCreation, cases.length);
-                should.equal(m.services.unknownt.sum.failedRuleCreation, 0);
+                    should.equal(m.services.unknownt.sum.ruleCreation, cases.length);
+                    should.equal(m.services.unknownt.sum.okRuleCreation, cases.length);
+                    should.equal(m.services.unknownt.sum.failedRuleCreation, 0);
 
-                return done();
-            });
+                    return done();
+                }
+            );
         });
 
         it('should increment an invalid rule creation', function(done) {
             var rule = utilsT.loadExample('./test/data/bad_rules/rule_without_name.json');
             metrics.GetDecorated(true); // reset metrics
             clients.PostRule(rule, function(error, data) {
-                var m = metrics.GetDecorated(true), msub;
+                var m = metrics.GetDecorated(true),
+                    msub;
                 should.not.exist(error);
                 data.should.have.property('statusCode', 400);
 
@@ -90,7 +95,8 @@ describe('Metrics', function() {
         it('should be increment correct delete', function(done) {
             metrics.GetDecorated(true); // reset metrics
             clients.DeleteRule('a very strange rule to exist', function(error, data) {
-                var m = metrics.GetDecorated(true), msub;
+                var m = metrics.GetDecorated(true),
+                    msub;
                 should.not.exist(error);
                 data.should.have.property('statusCode', 200);
 
@@ -113,9 +119,10 @@ describe('Metrics', function() {
             utilsT.setServerMessage('what a pity!');
             metrics.GetDecorated(true); // reset metrics
             clients.DeleteRule('a very strange rule to exist', function(error, data) {
-                var m = metrics.GetDecorated(true), msub;
+                var m = metrics.GetDecorated(true),
+                    msub;
                 should.not.exist(error);
-                data.should.have.property('statusCode', 500);
+                data.should.have.property('statusCode', 400);
 
                 should.exists(m);
                 should.exists(m.services);

--- a/test/component/notices_test.js
+++ b/test/component/notices_test.js
@@ -97,7 +97,7 @@ describe('Notices', function() {
                 function(c, callback) {
                     clients.PostNotice(c.object, function(error, data) {
                         should.not.exist(error);
-                        data.should.have.property('statusCode', 500);
+                        data.should.have.property('statusCode', 400);
                         return callback(null);
                     });
                 },

--- a/test/component/rules_test.js
+++ b/test/component/rules_test.js
@@ -202,7 +202,7 @@ describe('Rules', function() {
                 function(c, callback) {
                     clients.PostRule(c.object, function(error, data) {
                         should.not.exist(error);
-                        data.should.have.property('statusCode', 500);
+                        data.should.have.property('statusCode', 400);
                         return callback(null);
                     });
                 },
@@ -385,7 +385,7 @@ describe('Rules', function() {
             utilsT.setServerMessage('what a pity!');
             clients.DeleteRule('a very strange rule to exist', function(error, data) {
                 should.not.exist(error);
-                data.should.have.property('statusCode', 500);
+                data.should.have.property('statusCode', 400);
                 return done();
             });
         });

--- a/test/component/visualrules_test.js
+++ b/test/component/visualrules_test.js
@@ -155,7 +155,7 @@ describe('VisualRules', function() {
             utilsT.setServerMessage('what a pity!');
             clients.DeleteVR('a very strange rule to exist', function(error, data) {
                 should.not.exist(error);
-                data.should.have.property('statusCode', 500);
+                data.should.have.property('statusCode', 400);
                 return done();
             });
         });
@@ -388,7 +388,7 @@ describe('VisualRules', function() {
             utilsT.setServerMessage('what a pity!');
             clients.PutVR(rule.name, rule, function(error, data) {
                 should.not.exist(error);
-                data.should.have.property('statusCode', 500);
+                data.should.have.property('statusCode', 400);
                 return done();
             });
         });


### PR DESCRIPTION
fix for https://github.com/telefonicaid/perseo-fe/issues/539

- [x] test updated

This will return a 400 resposne with a payload like:

{"error":"error post to http://iot-perseo-core:8080/perseo-core/rules (Incorrect syntax near 'ev' expecting a right angle bracket ']' but found an identifier at line 1 column 75, please check the from clause [context ctxt$smartcity$ select *,'rule2name' as ruleName from pattern [eve ev=iotEvent(type='SensorMetter')]])","data":null}