### PR TITLE
[WIP] do not parse geo:json in a special way

### DIFF
--- a/lib/models/notices.js
+++ b/lib/models/notices.js
@@ -265,7 +265,8 @@ function processCBv2Notice(service, subservice, ncr, ix) {
                 (attrInfo.value && attrInfo.value.type && attrInfo.value.type === 'Point')
             ) {
                 location = parseLocation(attrInfo.value.coordinates.toString());
-                n[attr] = attrInfo.value.coordinates.toString();
+                // Parse geo:json also as usual JSON, not in a special way
+                n[attr] = attrInfo.value;
             } else if (attr === 'TimeInstant' || attrInfo.type === 'DateTime') {
                 date = parseDate(attrInfo.value);
                 n[attr] = attrInfo.value;


### PR DESCRIPTION
parse geo:json also as usual JSON not in a special way (maybe we should keep both for BW compatibility). So:

```
{
"loc": {
"type": "Point",
"coordinates": [
53.0859375,
53.12040528310657
]
}
}
```

will be expanded as:

loc__coordinates__0 : 53.0859375
loc__coordinates__1 : 53.12040528310657
loc__lat: 53.0859375
loc__long: 53.12040528310657
loc:__type: "Point"