### PR TITLE
Update perseo

### DIFF
--- a/bin/perseo
+++ b/bin/perseo
@@ -159,7 +159,7 @@ function loadConfiguration() {
             process.env.PERSEO_MONGO_USER && process.env.PERSEO_MONGO_PASSWORD ? process.env.PERSEO_MONGO_USER + ':' + process.env.PERSEO_MONGO_PASSWORD + '@' : '') +
             process.env.PERSEO_MONGO_ENDPOINT + '/orion' + 
             (process.env.PERSEO_MONGO_REPLICASET ? '?replicaSet=' + process.env.PERSEO_MONGO_REPLICASET : '') +
-            (process.env.PERSEO_MONGO_AUTH_SOURCE ? (process.env.PERSEO_MONGO_REPLICASET ? '&' : '?') + 'authSource=' + process.env.PERSEO_MONGO_AUTH_SOURCE : '');
+            (process.env.PERSEO_MONGO_AUTH_SOURCE ? (process.env.PERSEO_MONGO_REPLICASET ? '&' : '?') + 'authSource=' + process.env.PERSEO_MONGO_AUTH_SOURCE : ''));
     }
     if (process.env.PERSEO_IS_MASTER === 'true') {
         config.isMaster = true;

--- a/bin/perseo
+++ b/bin/perseo
@@ -154,7 +154,7 @@ function loadConfiguration() {
             process.env.PERSEO_MONGO_USER && process.env.PERSEO_MONGO_PASSWORD ? process.env.PERSEO_MONGO_USER + ':' + process.env.PERSEO_MONGO_PASSWORD + '@' : '') +
             process.env.PERSEO_MONGO_ENDPOINT + '/cep' + (
             (process.env.PERSEO_MONGO_REPLICASET ? '?replicaSet=' + process.env.PERSEO_MONGO_REPLICASET : '') +
-            (process.env.PERSEO_MONGO_AUTH_SOURCE ? (process.env.PERSEO_MONGO_REPLICASET ? '&' : '?') + 'authSource=' + process.env.PERSEO_MONGO_AUTH_SOURCE : '');
+            (process.env.PERSEO_MONGO_AUTH_SOURCE ? (process.env.PERSEO_MONGO_REPLICASET ? '&' : '?') + 'authSource=' + process.env.PERSEO_MONGO_AUTH_SOURCE : ''));
         config.orionDb.url = 'mongodb://' + (
             process.env.PERSEO_MONGO_USER && process.env.PERSEO_MONGO_PASSWORD ? process.env.PERSEO_MONGO_USER + ':' + process.env.PERSEO_MONGO_PASSWORD + '@' : '') +
             process.env.PERSEO_MONGO_ENDPOINT + '/orion' + 

--- a/bin/perseo
+++ b/bin/perseo
@@ -157,7 +157,7 @@ function loadConfiguration() {
             (process.env.PERSEO_MONGO_AUTH_SOURCE ? (process.env.PERSEO_MONGO_REPLICASET ? '&' : '?') + 'authSource=' + process.env.PERSEO_MONGO_AUTH_SOURCE : ''));
         config.orionDb.url = 'mongodb://' + (
             process.env.PERSEO_MONGO_USER && process.env.PERSEO_MONGO_PASSWORD ? process.env.PERSEO_MONGO_USER + ':' + process.env.PERSEO_MONGO_PASSWORD + '@' : '') +
-            process.env.PERSEO_MONGO_ENDPOINT + '/orion' + 
+            process.env.PERSEO_MONGO_ENDPOINT + '/orion' + (
             (process.env.PERSEO_MONGO_REPLICASET ? '?replicaSet=' + process.env.PERSEO_MONGO_REPLICASET : '') +
             (process.env.PERSEO_MONGO_AUTH_SOURCE ? (process.env.PERSEO_MONGO_REPLICASET ? '&' : '?') + 'authSource=' + process.env.PERSEO_MONGO_AUTH_SOURCE : ''));
     }


### PR DESCRIPTION
reopen https://github.com/telefonicaid/perseo-fe/pull/608 due to 
```
/home/avega/tid/fiware/perseo-fe/bin/perseo:157
                    (process.env.PERSEO_MONGO_AUTH_SOURCE ? (process.env.PERSEO_MONGO_REPLICASET ? '&' : '?') + 'authSource=' + process.env.PERSEO_MONGO_AUTH_SOURCE : '');
                                                                                                                                                                          ^

SyntaxError: Unexpected token ';'
    at wrapSafe (internal/modules/cjs/loader.js:915:16)
    at Module._compile (internal/modules/cjs/loader.js:963:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)
    at internal/main/run_main_module.js:17:47
```