### PR TITLE
Update package.json: mongo from 3.6.8 to 3.6.12

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
+Update mongodb dep driver from 3.6.8 to 3.6.12
 Fix: set 'None' as default type of entity for updateAction (#611)
 Add: PERSEO_MONGO_AUTH_SOURCE variable (#607)

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "body-parser": "~1.18.2",
     "express": "~4.16.4",
     "logops": "2.1.0",
-    "mongodb": "3.6.8",
+    "mongodb": "3.6.12",
     "ngsijs": "~1.3.0",
     "nodemailer": "6.4.18",
     "nodemailer-smtp-transport": "~2.7.2",


### PR DESCRIPTION
https://github.com/mongodb/node-mongodb-native/blob/v3.6.12/HISTORY.md

Bug Fixes

    NODE-3487: check for nullish aws mechanism property (#2957) (5902b4c)
    NODE-3528: add support for snappy v7 (#2947) (54f5c2d)
    NODE-1843: bulk operations ignoring provided sessions [PORT] (#2898) (9244b17)
    NODE-3199: unable to bundle driver due to uncaught require (#2903) (60efe9d)
    NODE-2035: Exceptions thrown from awaited cursor forEach do not propagate (#2852) (a917dfa)
    NODE-3150: added bsonRegExp option for v3.6 (#2843) (e4a9a57)
    NODE-3358: Command monitoring objects hold internal state references (#2858) (750760c)
    NODE-3380: perform retryable write checks against server (#2861) (621677a)
    NODE-3397: report more helpful error with unsupported authMechanism in initial handshake (#2876) (3ce148d)
    NODE-3309: remove redundant iteration of bulk write result (#2815) (fac9610)
    fix url parsing for a mongodb+srv url that has commas in the database name (#2789) (58c4e69)
