### PR TITLE
Upgrade logops dep from 2.1.0 to 2.1.2 due to colors dependency corruption

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
 Update mongodb dep driver from 3.6.8 to 3.6.12
 Fix: set 'None' as default type of entity for updateAction (#611)
 Add: PERSEO_MONGO_AUTH_SOURCE variable (#607)
+Upgrade logops dep from 2.1.0 to 2.1.2 due to colors dependency corruption

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "async": "2.6.2",
     "body-parser": "~1.18.2",
     "express": "~4.16.4",
-    "logops": "2.1.0",
+    "logops": "2.1.2",
     "mongodb": "3.6.12",
     "ngsijs": "~1.3.0",
     "nodemailer": "6.4.18",


### PR DESCRIPTION
logops < 2.1.2 depends on colors dependency, which recently have a corruption problem: https://snyk.io/blog/open-source-npm-packages-colors-faker/
