### PR TITLE
upgrade async dep from 2.6.2 version to 2.6.4 due to security vulnerability (CWE-1321)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- FIX: upgrade async dep from 2.6.2 version to 2.6.4 due to security vulnerability (CWE-1321)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-- FIX: upgrade async dep from 2.6.2 version to 2.6.4 due to security vulnerability (CWE-1321)
+- Upgrade async dep from 2.6.2 to 2.6.4 due to security vulnerability (CWE-1321)

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "keywords": [],
   "dependencies": {
-    "async": "2.6.2",
+    "async": "2.6.4",
     "body-parser": "~1.18.2",
     "express": "~4.16.4",
     "logops": "2.1.2",


### PR DESCRIPTION
https://github.com/telefonicaid/perseo-fe/security/dependabot/3

A vulnerability exists in Async through 3.2.1 for 3.x and through 2.6.3 for 2.x (fixed in 3.2.2 and 2.6.4), which could let a malicious user obtain privileges via the mapValues() method.