### PR TITLE
include original array value in event to perseo-core

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- ADD: keep original array value in event sent to perseo-core (#662)

--- a/lib/myutils.js
+++ b/lib/myutils.js
@@ -115,6 +115,10 @@ function flattenMap(key, targetMap) {
                 // skip objects which are arrays
                 newMap[key + k] = JSON.stringify(v);
             }
+            if (Object.prototype.toString.call(v) === '[object Array]') {
+                // skip objects which are arrays
+                newMap[key + k] = v;
+            }
         } else {
             newMap[key + k] = v;
         }


### PR DESCRIPTION
fix for issue https://github.com/telefonicaid/perseo-fe/issues/662
Maybe this PR also needs handle array in event in perseo-core 


NGSI event 

```json
{"subscriptionId":"6266459f0507b40e8e069e5b","data":[{"id":"WaterTank:disp1","type":"WaterTank","TimeInstant":{"type":"DateTime","value":"2022-04-25T09:05:11.042Z","metadata":{}},"temperaturas":{"type":"json","value":[1,2,3,4],"metadata":{}}}],"subservice":"/","service":"smartcity"}
```


perseo-fe:

time=2022-04-25T09:05:26.189Z | lvl=INFO | corr=372b8922-c62e-4aac-b0dd-91073bfcb6cd; cbnotif=1; node=bqZeyE3k0; perseocep=5 | trans=b01c1f65-1216-492a-83e8-828799f7a8d5 | op=/notices | path=/notices | comp=perseo-fe | srv=smartcity | subsrv=/ | from=::ffff:172.17.0.16 | msg=posting notice {"subscriptionId":"6266459f0507b40e8e069e5b","data":[{"id":"WaterTank:disp1","type":"WaterTank","TimeInstant":{"type":"DateTime","value":"2022-04-25T09:05:11.042Z","metadata":{}},"temperaturas":{"type":"json","value":[1,2,3,4],"metadata":{}}}],"subservice":"/","service":"smartcity"} 

time=2022-04-25T09:05:26.191Z | lvl=DEBUG | corr=372b8922-c62e-4aac-b0dd-91073bfcb6cd; cbnotif=1; node=bqZeyE3k0; perseocep=5 | trans=b01c1f65-1216-492a-83e8-828799f7a8d5 | op=/notices | path=/notices | comp=perseo-fe | srv=smartcity | subsrv=/ | from=::ffff:172.17.0.16 | msg=notice processed: {"noticeId":"d8aacce0-c476-11ec-8e6c-93a082700aa3","noticeTS":1650877526190,"id":"WaterTank:disp1","type":"WaterTank","isPattern":false,"subservice":"/","service":"smartcity","TimeInstant__type":"DateTime","TimeInstant":"2022-04-25T09:05:11.042Z","TimeInstant__ts":1650877511042,"TimeInstant__day":25,"TimeInstant__month":4,"TimeInstant__year":2022,"TimeInstant__hour":9,"TimeInstant__minute":5,"TimeInstant__second":11,"TimeInstant__millisecond":42,"TimeInstant__dayUTC":25,"TimeInstant__monthUTC":4,"TimeInstant__yearUTC":2022,"TimeInstant__hourUTC":9,"TimeInstant__minuteUTC":5,"TimeInstant__secondUTC":11,"TimeInstant__millisecondUTC":42,"temperaturas__type":"json","temperaturas__0":1,"temperaturas__1":2,"temperaturas__2":3,"temperaturas__3":4,"temperaturas":[1,2,3,4],"stripped":{"id":"WaterTank:disp1","type":"WaterTank","TimeInstant":{"type":"DateTime","value":"2022-04-25T09:05:11.042Z","metadata":{}},"temperaturas":{"type":"json","value":[1,2,3,4],"metadata":{}}}}


perseo-core
time=2022-04-25T09:05:26.204Z | lvl=DEBUG | from=::ffff:172.17.0.16 | corr=372b8922-c62e-4aac-b0dd-91073bfcb6cd; cbnotif=1; node=bqZeyE3k0; perseocep=5 | trans=cfa878fd-eb16-4d80-8ee7-7374ff41b6b0 | srv=smartcity | subsrv=/ | op=doPost | comp=perseo-core | msg=event as map: {TimeInstant__second=11, temperaturas__type=json, TimeInstant__hour=9, TimeInstant__day=25, stripped={temperaturas={metadata={}, type=json, value=[1, 2, 3, 4]}, id=WaterTank:disp1, type=WaterTank, TimeInstant={metadata={}, type=DateTime, value=2022-04-25T09:05:11.042Z}}, type=WaterTank, isPattern=false, TimeInstant__type=DateTime, temperaturas__1=2, TimeInstant__millisecond=42, temperaturas__2=3, subservice=/, TimeInstant__monthUTC=4, temperaturas__0=1, temperaturas__3=4, TimeInstant__year=2022, TimeInstant__yearUTC=2022, TimeInstant__month=4, id=WaterTank:disp1, TimeInstant__minute=5, TimeInstant__millisecondUTC=42, **temperaturas=[1, 2, 3, 4],** noticeTS=1650877526190, TimeInstant__hourUTC=9, noticeId=d8aacce0-c476-11ec-8e6c-93a082700aa3, TimeInstant__ts=1650877511042, service=smartcity, TimeInstant__minuteUTC=5, TimeInstant__secondUTC=11, TimeInstant=2022-04-25T09:05:11.042Z, TimeInstant__dayUTC=25}
