### PR TITLE
 fix EPL context + insert + select  rule (without expression)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,3 @@
-- Fix for EPL with context + insert + select rule (without expression) (#652)
+- Fix: for EPL with context + insert + select rule (without expression) (#652)
 - Fix: typo in non signal event internalCurentTime -> internalCurrentTime
 - Upgrade NodeJS version from 14-slim to 16-slim in Dockerfile

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
+- Fix for EPL with context + insert + select rule (without expression) (#652)
 - Upgrade NodeJS version from 14-slim to 16-slim in Dockerfile

--- a/lib/myutils.js
+++ b/lib/myutils.js
@@ -324,7 +324,7 @@ function ruleWithContext(rule) {
     var insertionPreContext;
     if (preSelectMatch) {
         preInsertMatch = preSelectMatch[0].match(/.+?(?=\insert )/i);
-        insertionPreContext = preInsertMatch ? preInsertMatch[0] : preSelectMatch[0];
+        insertionPreContext = preInsertMatch ? preInsertMatch[0] : '';
     } else {
         preInsertMatch = null;
         insertionPreContext = '';
@@ -351,7 +351,7 @@ function ruleWithContextTimedRule(rule) {
     var insertionPreContext;
     if (preSelectMatch) {
         preInsertMatch = preSelectMatch[0].match(/.+?(?=\insert )/i);
-        insertionPreContext = preInsertMatch ? preInsertMatch[0] : preSelectMatch[0];
+        insertionPreContext = preInsertMatch ? preInsertMatch[0] : '';
     } else {
         preInsertMatch = null;
         insertionPreContext = '';


### PR DESCRIPTION
fix for issue issue https://github.com/telefonicaid/perseo-fe/issues/652

Fix for this kind of rules:

 "insert into collectorstream select id||type as identificador, type as tipo, case when cast(h?,java.lang.Integer)>0 then 'OK' else 'NOK' end as collected, cast(h?,string) as str from iotEvent(type='A') where cast(h?,java.lang.Integer)%2=0;"

(without expressions)