### PR TITLE
ensure datetime attrs are in ISO format instead of epoc for nonSignal action 

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+- Fix: ensure datetime attrs from entity for nosignal events are in ISO format instead of epoc
 - Add: full detail about batch update error or success in logs
 - Fix: expanding an object variable in action of rule (#692)
 - Fix: for EPL with context + insert + select rule (without expression) (#652)

--- a/lib/models/noSignal.js
+++ b/lib/models/noSignal.js
@@ -86,7 +86,11 @@ function alertFunc(nsLineRule, entity) {
                 }
             }
             if (event[attrName] === undefined) {
-                event[attrName] = entity.attrs[attrName].value;
+                if (entity.attrs[attrName].type === 'DateTime') {
+                    event[attrName] = new Date(entity.attrs[attrName].value * 1000).toISOString();
+                } else {
+                    event[attrName] = entity.attrs[attrName].value;
+                }
             }
         });
 


### PR DESCRIPTION
perseo-fe is still reading from mongo entities, without use CB API (https://github.com/telefonicaid/perseo-fe/issues/549), so is getting DateTimes attributes in raw, which is epoc.