### PR TITLE
update actions with filter of timed based rules are not tried to execute after first failure updating entities

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-- Fix: actions of timed based rule with a filter are not tried to execute after a fail
+- Fix: update actions with filter of timed based rules are not tried to execute after first failure updating entities

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-
+- Fix: actions of timed based rule with a filter are not tried to execute after a fail

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-- Fix: update actions with filter of timed based rules are not tried to execute after first failure updating entities
+- Fix: update actions with filter of timed based rules are not tried to execute after first failure updating entities (#708)

--- a/lib/models/updateAction.js
+++ b/lib/models/updateAction.js
@@ -486,9 +486,14 @@ function doUpdateActionWithFilter(queryOptions, action, event, token, connection
                         // If the error was reported by Orion, error.correlator will be
                         // filled with the associated transaction id
                         metrics.IncMetrics(event.service, event.subservice, metrics.failedActionEntityUpdate);
-                        logger.warn('error v2.batchUpdate: %j trying update entity %j after event %j',
-                                    error, changes, event);
+                        logger.warn(
+                            'error v2.batchUpdate: %j trying update entity %j after event %j',
+                            error,
+                            changes,
+                            event
+                        );
                         alarm.raise(alarm.ORION, null, error);
+                        callback(error, null);
                     }
                 ); // batchUpdate
             } else {
@@ -538,8 +543,7 @@ function doUpdateAction(action, event, token, connection, callback) {
         },
         (error) => {
             metrics.IncMetrics(event.service, event.subservice, metrics.failedActionEntityUpdate);
-            logger.warn('error v2.batchUpdate: %j trying update entity %j after event %j',
-                        error, changes, event);
+            logger.warn('error v2.batchUpdate: %j trying update entity %j after event %j', error, changes, event);
             alarm.raise(alarm.ORION, null, error);
             callback(error, null);
         }


### PR DESCRIPTION
fix for https://github.com/telefonicaid/perseo-fe/issues/708