### PR TITLE
[WIP] Update ci.yml to mongo 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
     needs: unit-test
     services:
       mongodb:
-        image: mongo:4.4
+        image: mongo:5.0
         ports:
         - 27017:27017
     steps:


### PR DESCRIPTION
https://www.mongodb.com/docs/drivers/node/current/compatibility/

it seems that 3.6 mongo driver for nodejs is not compatible with new features for mongo 5.0 and 6.0, but it will work.
WIth mongo 7.0 driver 3.6 has not been tested, but seeing this PR it seems that works!