### PR TITLE
send sms actions one by one when multiple destinations

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Send multiple sms when multiple destination in sms action

--- a/lib/models/smsAction.js
+++ b/lib/models/smsAction.js
@@ -71,10 +71,6 @@ function doIt(action, event, callback) {
         if (options.sms && options.sms.from) {
             from = options.sms.from;
         }
-        msg = { to: buildTo(options.to), message: options.text, from: from };
-
-        metrics.IncMetrics(event.service, event.subservice, metrics.actionSMS);
-
         var url = config.sms.URL;
         var apiKey = config.sms.API_KEY;
         var apiSecret = config.sms.API_SECRET;
@@ -89,33 +85,42 @@ function doIt(action, event, callback) {
                 apiSecret = options.sms.API_SECRET;
             }
         }
-        myutils.requestHelper(
-            'post',
-            {
-                url: url,
-                json: true,
-                body: msg,
-                headers: {
-                    'User-Agent': 'request',
-                    API_KEY: apiKey,
-                    API_SECRET: apiSecret
-                }
-            },
-            function(err, data) {
-                myutils.logErrorIf(err, util.format('%s -> %s', url, msg.to));
-                if (err) {
-                    metrics.IncMetrics(event.service, event.subservice, metrics.failedActionSMS);
+        metrics.IncMetrics(event.service, event.subservice, metrics.actionSMS);
 
-                    alarm.raise(alarm.SMS);
-                } else {
-                    metrics.IncMetrics(event.service, event.subservice, metrics.okActionSMS);
+        var tos = buildTo(options.to);
 
-                    alarm.release(alarm.SMS);
+        for (var singleto of tos) {
+            msg = { to: [singleto], message: options.text, from: config.sms.from };
+
+            myutils.requestHelper(
+                'post',
+                {
+                    url: url,
+                    json: true,
+                    body: msg,
+                    headers: {
+                        'User-Agent': 'request',
+                        API_KEY: apiKey,
+                        API_SECRET: apiSecret
+                    }
+                },
+                function(err, data) {
+                    myutils.logErrorIf(err, util.format('%s -> %s', url, msg.to));
+                    if (err) {
+                        metrics.IncMetrics(event.service, event.subservice, metrics.failedActionSMS);
+                        alarm.raise(alarm.SMS);
+                    } else {
+                        metrics.IncMetrics(event.service, event.subservice, metrics.okActionSMS);
+                        alarm.release(alarm.SMS);
+                    }
+                    logger.info('smsAction.SendSMS done url:%s result:%j, msg: %j', url, err || data, msg);
+                    if (tos[tos.length - 1] === singleto) {
+                        // ensure callback is returned just one time
+                        return callback(err, data);
+                    }
                 }
-                logger.info('smsAction.SendSMS done url:%s result:%j, msg: %j', url, err || data, msg);
-                return callback(err, data);
-            }
-        );
+            );
+        }
     } catch (ex) {
         metrics.IncMetrics(event.service, event.subservice, metrics.failedActionSMS);
 

--- a/lib/models/smsAction.js
+++ b/lib/models/smsAction.js
@@ -103,8 +103,7 @@ function doIt(action, event, callback) {
                         API_SECRET: apiSecret
                     }
                 },
-                function(err, data) {
-                    // jshint ignore:line
+                function(err, data) { // jshint ignore:line
                     myutils.logErrorIf(err, util.format('%s -> %s', url, msg.to));
                     if (err) {
                         metrics.IncMetrics(event.service, event.subservice, metrics.failedActionSMS);

--- a/lib/models/smsAction.js
+++ b/lib/models/smsAction.js
@@ -91,7 +91,6 @@ function doIt(action, event, callback) {
 
         for (var singleto of tos) {
             msg = { to: [singleto], message: options.text, from: config.sms.from };
-
             myutils.requestHelper(
                 'post',
                 {
@@ -105,6 +104,7 @@ function doIt(action, event, callback) {
                     }
                 },
                 function(err, data) {
+                    // jshint ignore:line
                     myutils.logErrorIf(err, util.format('%s -> %s', url, msg.to));
                     if (err) {
                         metrics.IncMetrics(event.service, event.subservice, metrics.failedActionSMS);


### PR DESCRIPTION
Some SMS endpoint (acdc) is not able to receive multiple destinations to send sms.
We need provide a mechanics to ensure sms rules with multiple destinations are able to send sms over endpoints which does not allow multiple destinations.


related with https://github.com/telefonicaid/perseo-fe/issues/337