### PR TITLE
Do not search in entities collection with strict mode

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
+- Fix: Do not search in entities collection with strict mode by non_signal checker (#793)
 - Fix: do not invoke calback twice when error about trust not found in trustConf (#790)

--- a/lib/models/entitiesStore.js
+++ b/lib/models/entitiesStore.js
@@ -151,7 +151,7 @@ function findSilentEntitiesByMongo(service, subservice, ruleData, alterFunc, cal
 
     async.waterfall(
         [
-            db.collection.bind(db, entitiesCollectionName, { strict: true }),
+            db.collection.bind(db, entitiesCollectionName, { strict: false }),
             function(col, cb) {
                 col.find(criterion)
                     .batchSize(config.orionDb.batchSize)


### PR DESCRIPTION
Fix for issue https://github.com/telefonicaid/perseo-fe/issues/793

Maybe entities collection was removed when service was removed and still non signal rule still exists.
Or maybe there are not still entities collection in service/subservice