### PR TITLE
Update Dockerfile: remove unnecessary env  vars

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
 - Fix: deprecated mongo warnings about save and remove methods (#806)
 - Upgrade express from 4.19.2 to 4.20.0
 - Upgrade body-parser dep from 1.18.2 to 1.20.3
+- Fix: remove unnecessary env vars (PERSEO_MONGO_HOST and PERSEO_CORE_URL) from Dockerfile (#810)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
 - Fix: deprecated mongo warnings about save and remove methods (#806)
+- Fix: remove unnecessary env vars (PERSEO_MONGO_HOST and PERSEO_CORE_URL) from Dockerfile (#810)
 - Upgrade express from 4.19.2 to 4.20.0
 - Upgrade body-parser dep from 1.18.2 to 1.20.3
-- Fix: remove unnecessary env vars (PERSEO_MONGO_HOST and PERSEO_CORE_URL) from Dockerfile (#810)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -137,8 +137,6 @@ COPY --from=builder /opt/perseo-fe /opt/perseo-fe
 RUN npm install pm2@4.4.0 -g --no-package-lock --no-optional
 
 USER node
-ENV PERSEO_MONGO_HOST=mongodb
-ENV PERSEO_CORE_URL=http://corehost:8080
 ENV NODE_ENV=production
 
 # Expose 9090 for HTTP PORT
@@ -181,8 +179,6 @@ COPY --from=anon-user /etc/passwd /etc/shadow /etc/group /etc/
 WORKDIR /opt/perseo-fe
 
 USER nobody
-ENV PERSEO_MONGO_HOST=mongodb
-ENV PERSEO_CORE_URL=http://corehost:8080
 ENV NODE_ENV=production
 
 # Expose 9090 for HTTP PORT
@@ -223,8 +219,6 @@ RUN \
 	rm -rf /var/lib/apt/lists/* 
 
 USER node
-ENV PERSEO_MONGO_HOST=mongodb
-ENV PERSEO_CORE_URL=http://corehost:8080
 ENV NODE_ENV=production
 
 # Expose 9090 for HTTP PORT


### PR DESCRIPTION
Comes from https://github.com/telefonicaid/perseo-fe/issues/810
Remove the following unnecessary env vars from Dockerfile:
```
ENV PERSEO_MONGO_HOST=mongodb
ENV PERSEO_CORE_URL=http://corehost:8080
```