### PR TITLE
remove cache token when action uses trust

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+- Fix: Remove cache token when action rule uses trust at update or remove rule (#831)
 - Fix: prevent Perseo from crashing on startup with malformed configTrust file (#830)
 - Add: max time detection for non signal rules to not see an entity as silent due to is death (#824)
 - Add: reportIntervalAttr, maxTimeDetectionAttr and maxTimeDetection optional fields to non signal rules (#824)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
-- Fix: Remove cache token when action rule uses trust at update or remove rule (#831)
+- Fix: remove cache token when action rule uses trust at update or remove rule (#831)
 - Fix: prevent Perseo from crashing on startup with malformed configTrust file (#830)
 - Add: max time detection for non signal rules to not see an entity as silent due to is death (#824)
 - Add: reportIntervalAttr, maxTimeDetectionAttr and maxTimeDetection optional fields to non signal rules (#824)

--- a/lib/models/rules.js
+++ b/lib/models/rules.js
@@ -297,7 +297,7 @@ module.exports = {
                 delR2core.bind(null, rule),
                 function(cb) {
                     noSignal.DeleteNSRule(rule.service, rule.subservice, rule.name);
-                    if (rule.action.parameters.trust) {
+                    if (rule.action && rule.action.parameters && rule.action.parameters.trust) {
                         updateAction.removeCachedToken(rule.service, rule.subservice, rule.name);
                     }
                     cb(null);
@@ -343,7 +343,7 @@ module.exports = {
                     if (rule.nosignal) {
                         noSignal.DeleteNSRule(rule.service, rule.subservice, rule.name);
                     }
-                    if (rule.action.parameters.trust) {
+                    if (rule.action && rule.action.parameters && rule.action.parameters.trust) {
                         updateAction.removeCachedToken(rule.service, rule.subservice, rule.name);
                     }
                     cb(null);

--- a/lib/models/rules.js
+++ b/lib/models/rules.js
@@ -31,6 +31,7 @@ var util = require('util'),
     myutils = require('../myutils'),
     noSignal = require('./noSignal'),
     actions = require('./actions'),
+    updateAction = require('./updateAction'),
     logger = require('logops'),
     namePattern = /^[a-zA-Z0-9_-]+$/,
     MaxNameLength = 50,
@@ -296,6 +297,9 @@ module.exports = {
                 delR2core.bind(null, rule),
                 function(cb) {
                     noSignal.DeleteNSRule(rule.service, rule.subservice, rule.name);
+                    if (rule.action.parameters.trust) {
+                        updateAction.removeCachedToken(rule.service, rule.subservice, rule.name);
+                    }
                     cb(null);
                 }
             ],
@@ -338,6 +342,9 @@ module.exports = {
                 function(cb) {
                     if (rule.nosignal) {
                         noSignal.DeleteNSRule(rule.service, rule.subservice, rule.name);
+                    }
+                    if (rule.action.parameters.trust) {
+                        updateAction.removeCachedToken(rule.service, rule.subservice, rule.name);
                     }
                     cb(null);
                 },

--- a/lib/models/updateAction.js
+++ b/lib/models/updateAction.js
@@ -58,6 +58,7 @@ function getCachedToken(service, subservice, name) {
 
 function removeCachedToken(service, subservice, name) {
     if (tokens[service] && tokens[service][subservice] && tokens[service][subservice][name]) {
+        delete tokens[service][subservice][name];
         tokens[service][subservice][name] = undefined;
     }
 }

--- a/lib/models/updateAction.js
+++ b/lib/models/updateAction.js
@@ -56,6 +56,12 @@ function getCachedToken(service, subservice, name) {
     return tokens[service][subservice][name];
 }
 
+function removeCachedToken(service, subservice, name) {
+    if (tokens[service] && tokens[service][subservice] && tokens[service][subservice][name]) {
+        tokens[service][subservice][name] = undefined;
+    }
+}
+
 function generateToken(trust, cached) {
     cached.generating = true;
     logger.info('start generating token with trust %s', trust);
@@ -524,6 +530,7 @@ function doItWithToken(action, event, version, callback) {
         logger.debug('waiting token to be generated %s %s %s', service, subservice, ruleName);
         cached.emitter.once(newTokenEventName, newTokenListener);
     } else {
+        logger.debug('doRequestv2 with token %s', cached.token);
         doRequestV2(action, event, cached.token, cbDoReqUpdAxn);
     }
 }
@@ -541,6 +548,7 @@ function doIt(action, event, callback) {
 }
 
 module.exports.doIt = doIt;
+module.exports.removeCachedToken = removeCachedToken;
 
 /**
  * Constructors for possible errors from this module


### PR DESCRIPTION
Remove cache token when actions uses trust when update or remove a rule.

issue https://github.com/telefonicaid/perseo-fe/issues/831