### PR TITLE
REMOVE deprecated node versions from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,6 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 16.x
-          - 18.x
           - 20.x
           - 22.x
           - 24.x


### PR DESCRIPTION
Note we are using Node 24 in Dockerfile.