### PR TITLE
FIX set node 40 as minimum version in package.json

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-
+- Set Nodejs 20 as minimum version in packages.json (effectively removing Nodev16 and Nodev18 from supported versions)

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "main": "bin/perseo",
   "engines": {
-    "node": ">=16"
+    "node": ">=20"
   },
   "scripts": {
     "clean": "rm -rf package-lock.json && rm -rf node_modules && rm -rf coverage",


### PR DESCRIPTION
Note that in Dockerfile and ci.yml node 16 and 18 has been already removed.